### PR TITLE
Add error handling

### DIFF
--- a/src/Api/HttpApi.php
+++ b/src/Api/HttpApi.php
@@ -7,6 +7,8 @@
 
 namespace FAPI\Boilerplate\Api;
 
+use APIPHP\Boilerplate\Exception\Domain as DomainExceptions;
+use APIPHP\Boilerplate\Exception\DomainException;
 use Http\Client\HttpClient;
 use FAPI\Boilerplate\Hydrator\Hydrator;
 use FAPI\Boilerplate\RequestBuilder;
@@ -136,5 +138,27 @@ abstract class HttpApi
     private function createJsonBody(array $parameters)
     {
         return (count($parameters) === 0) ? null : json_encode($parameters, empty($parameters) ? JSON_FORCE_OBJECT : 0);
+    }
+
+    /**
+     * Handle HTTP errors.
+     *
+     * Call is controlled by the specific API methods.
+     *
+     * @param ResponseInterface $response
+     *
+     * @throws DomainException
+     */
+    protected function handleErrors(ResponseInterface $response)
+    {
+        switch ($response->getStatusCode()) {
+            case 404:
+                throw new DomainExceptions\NotFoundException();
+                break;
+
+            default:
+                throw new DomainExceptions\UnknownErrorException();
+                break;
+        }
     }
 }

--- a/src/Api/Stats.php
+++ b/src/Api/Stats.php
@@ -7,6 +7,7 @@
 
 namespace FAPI\Boilerplate\Api;
 
+use APIPHP\Boilerplate\Exception;
 use FAPI\Boilerplate\Exception\InvalidArgumentException;
 use FAPI\Boilerplate\Model\Stats\ShowResponse;
 use FAPI\Boilerplate\Model\Stats\TotalResponse;
@@ -21,6 +22,8 @@ class Stats extends HttpApi
      * @param array  $params
      *
      * @return ShowResponse
+     *
+     * @throws Exception
      */
     public function show(string $username, array $params = [])
     {
@@ -30,7 +33,10 @@ class Stats extends HttpApi
 
         $response = $this->httpGet(sprintf('/v1/stats/%s', rawurlencode($username)), $params);
 
-        // TODO handle non 200 responses
+        // Use any valid status code here
+        if ($response->getStatusCode() !== 200) {
+            $this->handleErrors($response);
+        }
 
         return $this->hydrator->hydrate($response, ShowResponse::class);
     }
@@ -44,7 +50,10 @@ class Stats extends HttpApi
     {
         $response = $this->httpGet('/v1/stats/total', $params);
 
-        // TODO handle non 200 responses
+        // Use any valid status code here
+        if ($response->getStatusCode() !== 200) {
+            $this->handleErrors($response);
+        }
 
         return $this->hydrator->hydrate($response, TotalResponse::class);
     }

--- a/src/Api/Tweet.php
+++ b/src/Api/Tweet.php
@@ -7,6 +7,8 @@
 
 namespace FAPI\Boilerplate\Api;
 
+use FAPI\Boilerplate\Exception;
+use FAPI\Boilerplate\Exception\Domain as DomainExceptions;
 use FAPI\Boilerplate\Exception\InvalidArgumentException;
 use FAPI\Boilerplate\Model\Tweet\CreateResponse;
 use FAPI\Boilerplate\Model\Tweet\DeleteResponse;
@@ -23,12 +25,17 @@ class Tweet extends HttpApi
      * @param array $params
      *
      * @return IndexResponse
+     *
+     * @throws Exception
      */
     public function index(array $params = [])
     {
         $response = $this->httpGet('/v1/tweets', $params);
 
-        // TODO handle non 200 responses
+        // Use any valid status code here
+        if ($response->getStatusCode() !== 200) {
+            $this->handleErrors($response);
+        }
 
         return $this->hydrator->hydrate($response, IndexResponse::class);
     }
@@ -37,6 +44,8 @@ class Tweet extends HttpApi
      * @param int $id
      *
      * @return ShowResponse
+     *
+     * @throws Exception
      */
     public function show(int $id)
     {
@@ -46,7 +55,10 @@ class Tweet extends HttpApi
 
         $response = $this->httpGet(sprintf('/v1/tweets/%d', $id));
 
-        // TODO handle non 200 responses
+        // Use any valid status code here
+        if ($response->getStatusCode() !== 200) {
+            $this->handleErrors($response);
+        }
 
         return $this->hydrator->hydrate($response, ShowResponse::class);
     }
@@ -57,6 +69,8 @@ class Tweet extends HttpApi
      * @param array  $hashtags
      *
      * @return CreateResponse
+     *
+     * @throws Exception
      */
     public function create(string $message, string $location, array $hashtags = [])
     {
@@ -76,7 +90,18 @@ class Tweet extends HttpApi
 
         $response = $this->httpPost('/v1/tweets/new', $params);
 
-        // TODO handle non 200 responses
+        // Use any valid status code here
+        if ($response->getStatusCode() !== 201) {
+            switch ($response->getStatusCode()) {
+                case 400:
+                    throw new DomainExceptions\ValidationException();
+                    break;
+
+                default:
+                    $this->handleErrors($response);
+                    break;
+            }
+        }
 
         return $this->hydrator->hydrate($response, CreateResponse::class);
     }
@@ -88,6 +113,8 @@ class Tweet extends HttpApi
      * @param array  $hashtags
      *
      * @return UpdateResponse
+     *
+     * @throws Exception
      */
     public function update(int $id, string $message, string $location, array $hashtags = [])
     {
@@ -107,7 +134,18 @@ class Tweet extends HttpApi
 
         $response = $this->httpPut(sprintf('/v1/tweets/%d/edit', $id), $params);
 
-        // TODO handle non 200 responses
+        // Use any valid status code here
+        if ($response->getStatusCode() !== 200) {
+            switch ($response->getStatusCode()) {
+                case 400:
+                    throw new DomainExceptions\ValidationException();
+                    break;
+
+                default:
+                    $this->handleErrors($response);
+                    break;
+            }
+        }
 
         return $this->hydrator->hydrate($response, UpdateResponse::class);
     }
@@ -116,6 +154,8 @@ class Tweet extends HttpApi
      * @param int $id
      *
      * @return DeleteResponse
+     *
+     * @throws Exception
      */
     public function delete(int $id)
     {
@@ -125,7 +165,10 @@ class Tweet extends HttpApi
 
         $response = $this->httpDelete(sprintf('/v1/tweets/%d', $id));
 
-        // TODO handle non 200 responses
+        // Use any valid status code here
+        if ($response->getStatusCode() !== 200) {
+            $this->handleErrors($response);
+        }
 
         return $this->hydrator->hydrate($response, DeleteResponse::class);
     }

--- a/src/Exception/Domain/NotFoundException.php
+++ b/src/Exception/Domain/NotFoundException.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+namespace APIPHP\Boilerplate\Exception\Domain;
+
+use APIPHP\Boilerplate\Exception\DomainException;
+
+/**
+ * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ */
+final class NotFoundException extends \Exception implements DomainException
+{
+}

--- a/src/Exception/Domain/NotFoundException.php
+++ b/src/Exception/Domain/NotFoundException.php
@@ -2,7 +2,7 @@
 
 /*
  * This software may be modified and distributed under the terms
- * of the MIT license.  See the LICENSE file for details.
+ * of the MIT license. See the LICENSE file for details.
  */
 
 namespace APIPHP\Boilerplate\Exception\Domain;

--- a/src/Exception/Domain/UnknownErrorException.php
+++ b/src/Exception/Domain/UnknownErrorException.php
@@ -2,7 +2,7 @@
 
 /*
  * This software may be modified and distributed under the terms
- * of the MIT license.  See the LICENSE file for details.
+ * of the MIT license. See the LICENSE file for details.
  */
 
 namespace APIPHP\Boilerplate\Exception\Domain;

--- a/src/Exception/Domain/UnknownErrorException.php
+++ b/src/Exception/Domain/UnknownErrorException.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+namespace APIPHP\Boilerplate\Exception\Domain;
+
+use APIPHP\Boilerplate\Exception\DomainException;
+
+/**
+ * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ */
+final class UnknownErrorException extends \Exception implements DomainException
+{
+}

--- a/src/Exception/Domain/ValidationException.php
+++ b/src/Exception/Domain/ValidationException.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+namespace APIPHP\Boilerplate\Exception\Domain;
+
+use APIPHP\Boilerplate\Exception\DomainException;
+
+/**
+ * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ */
+final class ValidationException extends \Exception implements DomainException
+{
+}

--- a/src/Exception/Domain/ValidationException.php
+++ b/src/Exception/Domain/ValidationException.php
@@ -2,7 +2,7 @@
 
 /*
  * This software may be modified and distributed under the terms
- * of the MIT license.  See the LICENSE file for details.
+ * of the MIT license. See the LICENSE file for details.
  */
 
 namespace APIPHP\Boilerplate\Exception\Domain;

--- a/src/Exception/DomainException.php
+++ b/src/Exception/DomainException.php
@@ -2,7 +2,7 @@
 
 /*
  * This software may be modified and distributed under the terms
- * of the MIT license.  See the LICENSE file for details.
+ * of the MIT license. See the LICENSE file for details.
  */
 
 namespace APIPHP\Boilerplate\Exception;

--- a/src/Exception/DomainException.php
+++ b/src/Exception/DomainException.php
@@ -1,0 +1,17 @@
+<?php
+
+/*
+ * This software may be modified and distributed under the terms
+ * of the MIT license.  See the LICENSE file for details.
+ */
+
+namespace APIPHP\Boilerplate\Exception;
+
+use APIPHP\Boilerplate\Exception;
+
+/**
+ * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
+ */
+interface DomainException extends Exception
+{
+}


### PR DESCRIPTION
Proposed solution for #1

Some explanation:

Each API method has the ability to decide which status codes are accepted, which mean errors. There can be common ones though, hence the common error handler. What I am not sure about is the exception message: should we add any? If so: should it be customized by the API method? Or 404 should always be "Resource not found"?