### PR TITLE
Use singular

### DIFF
--- a/src/Api/Stat.php
+++ b/src/Api/Stat.php
@@ -11,20 +11,20 @@ namespace FAPI\Boilerplate\Api;
 
 use FAPI\Boilerplate\Exception;
 use FAPI\Boilerplate\Exception\InvalidArgumentException;
-use FAPI\Boilerplate\Model\Stats\Stat;
+use FAPI\Boilerplate\Model\Stats\Stat as StatModel;
 use FAPI\Boilerplate\Model\Stats\Total;
 use Psr\Http\Message\ResponseInterface;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-final class Stats extends HttpApi
+final class Stat extends HttpApi
 {
     /**
      * @param string $username
      * @param array  $params
      *
-     * @return Stat|ResponseInterface
+     * @return StatModel|ResponseInterface
      *
      * @throws Exception
      */
@@ -45,7 +45,7 @@ final class Stats extends HttpApi
             $this->handleErrors($response);
         }
 
-        return $this->hydrator->hydrate($response, Stat::class);
+        return $this->hydrator->hydrate($response, StatModel::class);
     }
 
     /**

--- a/src/Api/Tweet.php
+++ b/src/Api/Tweet.php
@@ -15,7 +15,7 @@ use FAPI\Boilerplate\Exception\InvalidArgumentException;
 use FAPI\Boilerplate\Model\Tweet\TweetCreated;
 use FAPI\Boilerplate\Model\Tweet\TweetDeleted;
 use FAPI\Boilerplate\Model\Tweet\Tweets;
-use FAPI\Boilerplate\Model\Tweet\Tweet as Model;
+use FAPI\Boilerplate\Model\Tweet\Tweet as TweetModel;
 use FAPI\Boilerplate\Model\Tweet\TweetUpdated;
 use Psr\Http\Message\ResponseInterface;
 
@@ -50,7 +50,7 @@ final class Tweet extends HttpApi
     /**
      * @param int $id
      *
-     * @return Model|ResponseInterface
+     * @return TweetModel|ResponseInterface
      *
      * @throws Exception
      */
@@ -71,7 +71,7 @@ final class Tweet extends HttpApi
             $this->handleErrors($response);
         }
 
-        return $this->hydrator->hydrate($response, Model::class);
+        return $this->hydrator->hydrate($response, TweetModel::class);
     }
 
     /**

--- a/src/ApiClient.php
+++ b/src/ApiClient.php
@@ -9,7 +9,7 @@ declare(strict_types=1);
 
 namespace FAPI\Boilerplate;
 
-use FAPI\Boilerplate\Api\Stats;
+use FAPI\Boilerplate\Api\Stat;
 use FAPI\Boilerplate\Api\Tweet;
 use FAPI\Boilerplate\Hydrator\ModelHydrator;
 use FAPI\Boilerplate\Hydrator\Hydrator;
@@ -91,10 +91,10 @@ final class ApiClient
     }
 
     /**
-     * @return Api\Stats
+     * @return Api\Stat
      */
-    public function stats(): Stats
+    public function stats(): Stat
     {
-        return new Api\Stats($this->httpClient, $this->hydrator, $this->requestBuilder);
+        return new Api\Stat($this->httpClient, $this->hydrator, $this->requestBuilder);
     }
 }


### PR DESCRIPTION
I do also rename `use ...Tweet as Model` to `use ...Tweet as TweetModel`

This will fix #51